### PR TITLE
fix link to patchwork/releases and mention windows+linux builds

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,9 +20,9 @@ The easiest way to get started is using [patchwork](https://github.com/ssbc/patc
 
 ## Download and Install Patchwork
 
-On macOS, download the latest .dmg file from [patchwork/releases](https://github.com/mmckegg/patchwork/releases)
+Download installers for Windows, macOS and Linux from [patchwork/releases](https://github.com/ssbc/patchwork/releases)
 
-On other operating systems, with [node and npm installed](https://github.com/creationix/nvm):
+Or you can build from source with [node and npm installed](https://github.com/creationix/nvm):
 
 ```shell
 $ git clone https://github.com/ssbc/patchwork


### PR DESCRIPTION
@ahdinosaur whoops, this was linking to [mmckegg/patchwork/releases](https://github.com/mmckegg/patchwork/releases) (OH NO THAT'S THE WORST).

I also took the liberty of updating the text to say that you can download Linux+Windows builds now.