### PR TITLE
Add link collection to ssb guides section

### DIFF
--- a/guides/index.md
+++ b/guides/index.md
@@ -3,3 +3,4 @@
 This section is a collection of guides that are useful to introductions for Scuttlebutt applications and tools.
 
 - [First steps with sbot, a command line tool for Scuttlebutt](./cli-first-steps.md)
+- [A link collection of ssb resources, clients and pubs](https://cblgh.org/ssb.txt)


### PR DESCRIPTION
Add a link to https://cblgh.org/ssb.txt, which is a document I'm maintaining containing resources, clients and such that I found useful when first learning about ssb!