### PR TITLE
Continue to minimize the landing page

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,11 +21,11 @@
 
 ## How To Get Started
 
-The easiest way to get started is using [Patchwork](https://github.com/ssbc/patchwork), a classic social networking [application](./applications.md).
+The easiest way to get started is using [Patchwork](http://dinosaur.is/patchwork-downloader/), an application for navigating and talking on scuttlebutt.
 
 ![screenshot of Patchwork](./assets/patchwork.jpg)
 
-1. [Download an Installer](https://github.com/ssbc/patchwork/releases) for Windows, macOS and Linux
+1. [Download Patchwork](http://dinosaur.is/patchwork-downloader/) for Windows, macOS and Linux
 2. Get a [pub invite code](https://github.com/ssbc/scuttlebot/wiki/Pub-Servers)  
 3. Use the pub invite : in Patchwork click `+ Join Pub` and paste the invite code
 
@@ -34,7 +34,7 @@ Read more about Pubs and their role [here](./concepts/pub.md).
 
 ## Join The Community
 
-Check out the following channels by typing their name (with #) in the search bar:
+Once onboard patchwork, check out the following channels by typing their name (with #) in the search bar:
 - **#new-people**: introduce yourself
 - **#faq**: first impressions, what is confusing as a new user?
 - **#patchwork**: report bugs, suggestions, etc
@@ -51,11 +51,13 @@ Here are some other favourites:
 
 Please note that this project is released with a [Contributor Code of Conduct](code-of-conduct.md). By participating in this project you agree to abide by its terms.
 
-## About This Handbook
+## Have Other Questions?
 
-To view the public handbook, browse to [scuttlebutt.nz](https://www.scuttlebutt.nz)
+A great place to learn more is our [FAQ page](faq/index.md)
 
-The handbook is organized by topics:
+In addition, you'll find a wealth of resources within this handbook, accessible through the sidebar.  
+
+The resources are organized by these topics:
 
 * [Contributing](contributing.md)
 * [Talks](talks.md)
@@ -67,13 +69,3 @@ The handbook is organized by topics:
 * [Concepts](concepts/index.md)
 * [Guides](guides/index.md)
 * [Glossary](glossary.md)
-
-## Other documentation
-
-Over time we have scattered documentation around in a few places:
-
-- [scuttlebot.io](https://scuttlebot.io)
-- [ssbc.github.io](https://ssbc.github.io)
-
-[Please help us consolidate this here](contributing.md#contributing-documentation)!
-


### PR DESCRIPTION
In an effort to avoid the site visitor being navigated away from our page, and into some new (potentially overwhelming) site like github, I made a few big changes to our readme.

Big one: I changed the patchwork install page from github to the one that Mikey made for our onboarding link generator.  This way a new visitor just needs to click a single button and they are ready to go.

I also removed the opening link to our "applications" page, as I think this page is more confusing than helpful for the first-time visitor.

I also changed the wording for the "about this handbook" so that a new visitor can find the FAQ faster, and not be confused by a list of other sites they should check out and also consolidate.  I feel that section would be better served in the FAQ about helping.