### PR TITLE
Add actual blow by blow steps to the delete page

### DIFF
--- a/faq/basics/delete.md
+++ b/faq/basics/delete.md
@@ -16,7 +16,7 @@ If things get 'corrupted' locally and you want to resync your .ssb data from you
 
 These instructions assume you are using terminal on OSX or Linux but, the same steps should also run on Windows.
 
-First **back up your .ssb dir** which is probably in your home directory, ```~/.ssb```
+First **back up your .ssb dir** which is probably in your home directory, `~/.ssb`
 ```
 > cd ~                                          
 > mkdir ssb_bak                                                                   
@@ -43,7 +43,7 @@ If you are using ssb-server (previously sbot) you can do this as follows.
 ssb-server start
 ```
 
-It will take a while to resync everything so give it a while. It's imporant to wait until your feed completely syncs before posting (or linking) anything, or you can fork your feed. Once your ```~/.ssb``` dir is restored you can safely restart patchwork or other programs which will read from the same dir.
+It will take a while to resync everything so give it a while. It's imporant to wait until your feed completely syncs before posting (or linking) anything, or you can fork your feed. Once your `~/.ssb` dir is restored you can safely restart patchwork or other programs which will read from the same dir.
 
 ---
 **Sources**

--- a/faq/basics/delete.md
+++ b/faq/basics/delete.md
@@ -43,7 +43,7 @@ If you are using ssb-server (previously sbot) you can do this as follows.
 ssb-server start
 ```
 
-It will take a while to resync everything so give it a while - something like 20 minutes on a good connection. It is not necessary for it to completely sync. Once your ```~/.ssb``` dir is restored you can safely restart patchwork or other programs which will read from the same dir.
+It will take a while to resync everything so give it a while. It's imporant to wait until your feed completely syncs before posting (or linking) anything, or you can fork your feed. Once your ```~/.ssb``` dir is restored you can safely restart patchwork or other programs which will read from the same dir.
 
 ---
 **Sources**

--- a/faq/basics/delete.md
+++ b/faq/basics/delete.md
@@ -10,6 +10,41 @@ If you wish to recover your account, you would have to have at least one file: `
 
 But if you just want delete your account on purpose, your friends may still temporarily have your messages stored. In this, again, it is similar to real-life social relationships. If you decide one day to ditch all your friends and move away... it doesn't mean these friends will forget about you. And they may still talk about that one time you screamsang Carly Rae Jepsen at karaoke.  But as life continues, and you all make new friends and connections and live new stories, that specific memory may become harder to recall.
 
+## Deleting and 'resetting' your .ssb database
+
+If things get 'corrupted' locally and you want to resync your .ssb data from your peers you could do the following to create a clean copy,  
+
+These instructions assume you are using terminal on OSX or Linux but, the same steps should also run on Windows.
+
+First **back up your .ssb dir** which is probably in your home directory, ```~/.ssb```
+```
+> cd ~                                          
+> mkdir ssb_bak                                                                   
+> cp -rp .ssb ssb_bak
+```
+
+_If you get this error on the last step, you can safely ignore it:_
+```                                                               
+cp: .ssb/socket: Operation not supported on socket
+```
+
+Next **copy your secret file and gossip.json** back 
+```
+rm -rf .ssb
+mkdir .ssb
+cp ssb_bak/.ssb/secret .ssb
+cp ssb_bak/.ssb/gossip.json .ssb
+```
+
+You can now **resync from your peers** by starting your preferred ssb server
+
+If you are using ssb-server (previously sbot) you can do this as follows. 
+```
+ssb-server start
+```
+
+It will take a while to resync everything so give it a while - something like 20 minutes on a good connection. It is not necessary for it to completely sync. Once your ```~/.ssb``` dir is restored you can safely restart patchwork or other programs which will read from the same dir.
+
 ---
 **Sources**
-* Answer compiled from [this thread.](https://viewer.scuttlebot.io/%259tfp%2F8bCful8ZvMskklXYO6C%2F7%2FgIaBKH9jNwJI6%2BTM%3D.sha256) Shoutouts to @claytonkoenig for asking the question, and to @ezdiy and @keks for their answers.
+* Answer compiled from [this thread.](https://viewer.scuttlebot.io/%259tfp%2F8bCful8ZvMskklXYO6C%2F7%2FgIaBKH9jNwJI6%2BTM%3D.sha256) and [this thread](https://viewer.scuttlebot.io/%AyrmGv9lfW6cFb2DVUGjUW//OdaEo3bRGELZkgZGmWs=.sha256) Shoutouts to @claytonkoenig for asking the question, and to @ezdiy, @keks and others for their answers.


### PR DESCRIPTION
Just a suggestion that it would be helpful to have actual blow by blow steps for what actually works. These are the steps that work. I found that deleting .ssb dir entirely, and then letting patchwork restart then copying secret back in didnt work. Also, a bunch of other things that  I tried also didn't work so just noting down a reset procedure that works seems like a good idea?

NB I called it ssb-server not sbot because that's the most recent version at time of writing.. even though its sbot most of the docs

No worries if chucking this suggestion clashes with a bigger documentation push just wanted to note it while it was a concern for me.