### PR TITLE
Convert all links to viewer.scuttlebot.io into plain hashes

### DIFF
--- a/applications.md
+++ b/applications.md
@@ -249,7 +249,7 @@ Source code: `ssb://%zoL1riX2mELF0j3dydWtQ+go4nI4jaByvm5Z02cRyaQ=.sha256`
 
 <img src="./assets/screenshots/recipes.gif" alt="recipes" class="shadow" />
 
-([%6ZmujAEWSxaNo5olG+gPoUq/pLrD5iPBdvoBuy8AHPg=.sha256](https://viewer.scuttlebot.io/%256ZmujAEWSxaNo5olG%2BgPoUq%2FpLrD5iPBdvoBuy8AHPg%3D.sha256))
+- %6ZmujAEWSxaNo5olG+gPoUq/pLrD5iPBdvoBuy8AHPg=.sha256
 
 ---
 

--- a/faq/applications/moving-ssb-apps.md
+++ b/faq/applications/moving-ssb-apps.md
@@ -8,4 +8,5 @@ Yep! If you use the same private key (found at .ssb/secret).  This is a short an
 
 ---
 **Sources**
-* The answer is taken from [this thread.](https://viewer.scuttlebot.io/%25m8%2B25i3i5LCRioA%2FCAqARVb0HNA6TTdvi4B0CxBd8eo%3D.sha256)  Shoutout to @ralphtheninja for the awesome answer.
+
+- %25m8%2B25i3i5LCRioA%2FCAqARVb0HNA6TTdvi4B0CxBd8eo%3D.sha256  Shoutout to @ralphtheninja for the awesome answer.

--- a/faq/applications/multiple-devices.md
+++ b/faq/applications/multiple-devices.md
@@ -6,7 +6,9 @@
 
 Currently, you cannot.  Identities are tied to a single user on a single device.  You could use scuttlebutt on multiple devices, but you would be maintaining multiple identities and feeds.
 
-There is an ongoing conversation around this, though, that you can follow [here](https://viewer.scuttlebot.io/%25PwYjgBO4qwpz4ya%2BFLiXphHyuwdFHntrMGd%2FbXJc17o%3D.sha256)
+There is an ongoing conversation around this, though, that you can follow here:
+
+- %25PwYjgBO4qwpz4ya%2BFLiXphHyuwdFHntrMGd%2FbXJc17o%3D.sha256
 
 ---
 **Sources**

--- a/faq/applications/patchwork-and-patchbay.md
+++ b/faq/applications/patchwork-and-patchbay.md
@@ -14,4 +14,6 @@ What this means is that if you are on Patchwork and your friend is on Patchbay, 
 
 ---
 **Sources**
-* The answer is compiled from multiple posts from [this thread.](https://viewer.scuttlebot.io/%25m8%2B25i3i5LCRioA%2FCAqARVb0HNA6TTdvi4B0CxBd8eo%3D.sha256)  Shoutout to @ralphtheninja for the awesome answer.
+* The answer is compiled from multiple posts from this thread:
+
+- %25m8%2B25i3i5LCRioA%2FCAqARVb0HNA6TTdvi4B0CxBd8eo%3D.sha256  Shoutout to @ralphtheninja for the awesome answer.

--- a/faq/basics/data-live.md
+++ b/faq/basics/data-live.md
@@ -16,4 +16,6 @@ The messages you've sent live in a leveldb database within this folder (specific
 [Taming the Terminal](https://www.bartbusschots.ie/s/blog/taming-the-terminal/)
 
 **Sources**
-* Answer compiled mostly from experience and [this thread.](https://viewer.scuttlebot.io/%25bUEQtn85jtL8Vxjup4sS%2F7wcaswS4fThUPVH7G5IvjU%3D.sha256)  Shoutouts to @cryptix for the answer on encryption and the leveldb database.
+* Answer compiled mostly from experience and this thread:
+
+- ssb://%25bUEQtn85jtL8Vxjup4sS%2F7wcaswS4fThUPVH7G5IvjU%3D.sha256  Shoutouts to @cryptix for the answer on encryption and the leveldb database.

--- a/faq/basics/delete.md
+++ b/faq/basics/delete.md
@@ -47,4 +47,9 @@ It will take a while to resync everything so give it a while. It's imporant to w
 
 ---
 **Sources**
-* Answer compiled from [this thread.](https://viewer.scuttlebot.io/%259tfp%2F8bCful8ZvMskklXYO6C%2F7%2FgIaBKH9jNwJI6%2BTM%3D.sha256) and [this thread](https://viewer.scuttlebot.io/%AyrmGv9lfW6cFb2DVUGjUW//OdaEo3bRGELZkgZGmWs=.sha256) Shoutouts to @claytonkoenig for asking the question, and to @ezdiy, @keks and others for their answers.
+* Answer compiled from these threads:
+
+- %9tfp/8bCful8ZvMskklXYO6C/7/gIaBKH9jNwJI6+TM=.sha256
+- %AyrmGv9lfW6cFb2DVUGjUW//OdaEo3bRGELZkgZGmWs=.sha256
+
+Shoutouts to @claytonkoenig for asking the question, and to @ezdiy, @keks and others for their answers.

--- a/faq/basics/gossip.md
+++ b/faq/basics/gossip.md
@@ -14,5 +14,9 @@ There are some great pages posted on scuttlebutt.nz that go into gossip as a pro
 ----
 
 **Sources**
-* Answer taken from section of [this thread.](https://viewer.scuttlebot.io/%25m8%2B25i3i5LCRioA%2FCAqARVb0HNA6TTdvi4B0CxBd8eo%3D.sha256) Shoutouts to @ferrouswheel for asking the question! 
+* Answer taken from section of this thread:
+
+- %m8+25i3i5LCRioA/CAqARVb0HNA6TTdvi4B0CxBd8eo=.sha256
+
+Shoutouts to @ferrouswheel for asking the question! 
 

--- a/faq/basics/patchwork-vs-scuttlebutt.md
+++ b/faq/basics/patchwork-vs-scuttlebutt.md
@@ -19,5 +19,8 @@ A better analogy for all of this would be that Patchwork is a car you ride in an
 
 ----
 **Sources**
-* The answer is compiled from multiple posts from [this thread.](https://viewer.scuttlebot.io/%25m8%2B25i3i5LCRioA%2FCAqARVb0HNA6TTdvi4B0CxBd8eo%3D.sha256)  Shoutout to @dominic for the car analogy.
+* The answer is compiled from multiple posts from this thread:
 
+- %m8+25i3i5LCRioA/CAqARVb0HNA6TTdvi4B0CxBd8eo=.sha256
+
+Shoutout to @dominic for the car analogy.

--- a/faq/basics/port.md
+++ b/faq/basics/port.md
@@ -13,4 +13,6 @@ Scuttlebot uses the ports 8008 and 8989.
 
 *Sources*
 
-This FAQ is thanks to [this thread](https://viewer.scuttlebot.io/%252x%2FOMldq1XbwJtUWqQg2HF4z0fsdfIvuG4ezcS%2FQcww%3D.sha256) started by CustomDesigned and answered by CustomDesigned and ev.
+This FAQ is thanks to this thread started by CustomDesigned and answered by CustomDesigned and ev:
+
+- %2x/OMldq1XbwJtUWqQg2HF4z0fsdfIvuG4ezcS/Qcww=.sha256

--- a/faq/basics/pub.md
+++ b/faq/basics/pub.md
@@ -15,4 +15,6 @@ This concept of pubs is one of the densest and most complex with Scuttlebutt. Yo
 
 ---
 **Sources**
-* [_Answer compiled mostly from this thread. Shoutouts to @mixmix for the original answer.](https://viewer.scuttlebot.io/%25lxUClUyoEVHQ0OIRq2uslFPcPJeJ2UmPROKdl996RFU%3D.sha256)
+* Answer compiled mostly from this thread. Shoutouts to @mixmix for the original answer:
+
+- %lxUClUyoEVHQ0OIRq2uslFPcPJeJ2UmPROKdl996RFU=.sha256

--- a/faq/basics/size.md
+++ b/faq/basics/size.md
@@ -38,4 +38,9 @@ In both cases, blobs take up significant space.  If this is a concern, you can d
 
 ----
 **Sources**
-* Answer compiled from [this thread](https://viewer.scuttlebot.io/%25bUEQtn85jtL8Vxjup4sS%2F7wcaswS4fThUPVH7G5IvjU%3D.sha256) and [this thread](https://viewer.scuttlebot.io/%25Ayi7UUbJnIZ12S%2FgbHof60oHBlmjdrv7TUyFCq5cOTQ%3D.sha256)  Shoutouts to @cryptix and @keks for awesome answers.
+* Answer compiled from these threads:
+
+- %bUEQtn85jtL8Vxjup4sS/7wcaswS4fThUPVH7G5IvjU=.sha256
+- %Ayi7UUbJnIZ12S/gbHof60oHBlmjdrv7TUyFCq5cOTQ=.sha256
+
+Shoutouts to @cryptix and @keks for awesome answers.

--- a/faq/channels/channel-messages.md
+++ b/faq/channels/channel-messages.md
@@ -11,4 +11,6 @@ You _would_ see those messages if you later became friends (which is likely, sin
 ---
 
 **Sources**
-* Answer taken from [this thread](https://viewer.scuttlebot.io/%256Jajc1TsINMv6%2FUMSEHThi0uTcHIbdluzyOVORsZkr8%3D.sha256)
+* Answer taken from this thread:
+
+- %6Jajc1TsINMv6/UMSEHThi0uTcHIbdluzyOVORsZkr8=.sha256

--- a/faq/channels/channel-sort.md
+++ b/faq/channels/channel-sort.md
@@ -12,6 +12,8 @@ They are sorted by recent activity, favoring subscribed channels first.
 
 **Sources**
 
-* Answer taken basically straight up from [this thread](https://viewer.scuttlebot.io/%25grj55XZxFnuMf%2BUqeQaZHC2RXRQcck%2FWzl1L1FeXP1o%3D.sha256).  Shoutouts to @Alanna for asking and @Jeremy for answering!
+* Answer taken basically straight up from this thread:
 
+- %grj55XZxFnuMf+UqeQaZHC2RXRQcck/Wzl1L1FeXP1o=.sha256
 
+Shoutouts to @Alanna for asking and @Jeremy for answering!

--- a/faq/channels/channels.md
+++ b/faq/channels/channels.md
@@ -10,9 +10,14 @@ Channels are a way to organize your messages and conversations, but offer no add
 
 An analogy! If scuttlebutt works as a big diary--with each message you post added to the end of your diary and shared with your friends-- then channels are like writing a diary entry with a different colored pen.  They are simply a pleasing,  personal form of organization.  But  luckily your friends follow this same technique and use the same pens and so you can easily share your related messages.
 
-There has been discussion on whether channels should work more like hashtags, and to have a distinct "group" feature that would behave closer to a slack channel or discussion group.  You can read more of that conversation [here](https://viewer.scuttlebot.io/%25gTHLf3Rlc48RSjwATVDJZpe9VlWGfxMmio1%2Bo3KXvjA%3D.sha256)
+There has been discussion on whether channels should work more like hashtags, and to have a distinct "group" feature that would behave closer to a slack channel or discussion group.  You can read more of that conversation here:
+
+- %gTHLf3Rlc48RSjwATVDJZpe9VlWGfxMmio1+o3KXvjA=.sha256
 
 ---
 **Sources**
-* Answer compiled from multiple posts on [this thread](https://viewer.scuttlebot.io/%256Jajc1TsINMv6%2FUMSEHThi0uTcHIbdluzyOVORsZkr8%3D.sha256) Shoutouts to @kas, @dinosaur, and @dominic for the help!
+* Answer compiled from multiple posts on this thread:
 
+%6Jajc1TsINMv6/UMSEHThi0uTcHIbdluzyOVORsZkr8=.sha256
+
+Shoutouts to @kas, @dinosaur, and @dominic for the help!


### PR DESCRIPTION
As they will be picked-up by [gitbook-plugin-ssb](https://github.com/ssbc/gitbook-plugin-ssb).

This increases the consistency in the handbook