### PR TITLE
Fix format of pub messages to match reality

### DIFF
--- a/guides/ssb-server/announce-a-pub-server.md
+++ b/guides/ssb-server/announce-a-pub-server.md
@@ -3,10 +3,10 @@
 To announce a pub server, publish this `pub` message:
 
 ```bash
-ssb-server publish --type pub --pub.link {feedId} --pub.host {string} --pub.port {number}
+ssb-server publish --type pub --address.key {feedId} --address.host {string} --address.port {number}
 ```
 ```js
-sbot.publish({ type: 'pub', pub: { link: feedId, host: string, port: number } }, cb)
+sbot.publish({ type: 'pub', address: { key: feedId, host: string, port: number } }, cb)
 ```
 
 Scuttlebot, and any user that follows you, will add the pub to their peer list, and begin contacting it for syncing.


### PR DESCRIPTION
Fixes the schema of `pub` messages on "Announce a Pub Server" page.