### PR TITLE
Remove some ambiguity around pub announcements

### DIFF
--- a/guides/pubs/announce-a-pub-server.md
+++ b/guides/pubs/announce-a-pub-server.md
@@ -1,12 +1,27 @@
 # Announce a Pub Server
 
-To announce a pub server, publish this `pub` message:
+To announce a pub server, publish this `pub` message, replacing the parts in quotes with your pub server's values:
 
 ```bash
-ssb-server publish --type pub --address.key {feedId} --address.host {string} --address.port {number}
-```
-```js
-sbot.publish({ type: 'pub', address: { key: feedId, host: string, port: number } }, cb)
+ssb-server publish --type pub --address.key "@myPubId.ed25519" --address.host "awesomepub.mydomain.org" --address.port 8008
 ```
 
-Scuttlebot, and any user that follows you, will add the pub to their peer list, and begin contacting it for syncing.
+You can achieve the same from JavaScript like such:
+```js
+sbot.publish({ type: 'pub', address: { key: pubId, host: string, port: number } }, cb)
+```
+
+`ssb-server`, and any user that follows you, will add the pub to their peer list, and begin contacting it for syncing.
+
+If you do this correctly, the newest message of your pub should look like this:
+
+```terminal
+$ ssb-server getLatest '@myPubId=.ed25519' | jq '.value.content'
+{
+  "type": "pub",
+  "address": {
+    "key": "@myPubId.ed25519",
+    "host": "awesomepub.mydomain.org",
+    "port": 8008
+}
+```


### PR DESCRIPTION
The use of `{curly braces}` was a little unfortunate since they are also heavily used in JSON/JS notation.
Hopefully this clears out any ambiguity around what should be done and what the result should be.